### PR TITLE
fix(runtime): use 'void' to declare prototypes without parameters

### DIFF
--- a/c-runtime/Makefile
+++ b/c-runtime/Makefile
@@ -23,7 +23,7 @@ OUTDIR := $(abspath ./out)
 # Default Flags #
 #################
 
-CFLAGS ?= -pedantic -Wall #-Werror
+CFLAGS ?= -pedantic -Wall -Werror
 CFLAGS += -std=c11 -I$(INCLUDEDIR)
 CFLAGS += -ffile-prefix-map=$(SRCDIR)=.
 # make getline() (see man getline(3)) available

--- a/c-runtime/include/builtins-setup.h
+++ b/c-runtime/include/builtins-setup.h
@@ -107,6 +107,6 @@ extern __MPyObj *__mpy_super;
 
 void __mpy_builtins_setup(void);
 
-void __mpy_builtins_cleanup();
+void __mpy_builtins_cleanup(void);
 
 #endif

--- a/c-runtime/include/builtins-setup.h
+++ b/c-runtime/include/builtins-setup.h
@@ -105,10 +105,8 @@ extern __MPyObj *__MPyFunc_Object_init;
 
 extern __MPyObj *__mpy_super;
 
-void __mpy_builtins_setup();
+void __mpy_builtins_setup(void);
 
 void __mpy_builtins_cleanup();
 
 #endif
-
-

--- a/c-runtime/include/mpy_obj.h
+++ b/c-runtime/include/mpy_obj.h
@@ -4,7 +4,7 @@
 #include "stdbool.h"
 
 /**
- * @file 
+ * @file
  */
 
 /**
@@ -38,24 +38,24 @@ struct __MPyObj {
     /**
      * unique id of the object
      */
-    unsigned int id; 
+    unsigned int id;
     /**
      * pointer to the content of the object - managed by type specific implementation
      */
-    void *content; 
+    void *content;
     /**
      * pointer to the refCount - *not* managed by type specific implementation
      */
-    unsigned int refCount; 
+    unsigned int refCount;
     /**
      * pointer to the objects type
      */
-    __MPyObj *type; 
+    __MPyObj *type;
     /**
-     * allow an object to temporarily keep its content longer than refCount implies 
+     * allow an object to temporarily keep its content longer than refCount implies
      * by setting this to true instead of decrementing refCount
      */
-    bool temporary; 
+    bool temporary;
     /**
      * Allow builtin objects with additional allocations inside content to deallocate them.
      */
@@ -86,7 +86,7 @@ __MPyObj* __mpy_obj_return(__MPyObj*);
 /**
  * Initialises a new __MPyObj.
  */
-__MPyObj* __mpy_obj_new();
+__MPyObj* __mpy_obj_new(void);
 
 /**
  * Increment the ref count if the object is used in another context.

--- a/c-runtime/include/type-hierarchy/object.h
+++ b/c-runtime/include/type-hierarchy/object.h
@@ -3,7 +3,7 @@
 
 #include "mpy_obj.h"
 
-__MPyObj *__mpy_obj_init_object();
+__MPyObj *__mpy_obj_init_object(void);
 
 __MPyObj* __mpy_object_func_str_impl(__MPyObj *args, __MPyObj *kwargs);
 

--- a/c-runtime/src/builtins-setup.c
+++ b/c-runtime/src/builtins-setup.c
@@ -122,7 +122,7 @@ __MPyObj *__MPyFunc_Object_init;
 
 __MPyObj *__mpy_super;
 
-void __mpy_builtins_setup() {
+void __mpy_builtins_setup(void) {
     // idea: since the basic parts of the type hierarchy recursively depend on one another
     // (e. g. type inherits from object, but object itself is an instance of the type class)
     // first init the base MpyObj and afterwards initialise the type so all pointers point in the correct location

--- a/c-runtime/src/builtins-setup.c
+++ b/c-runtime/src/builtins-setup.c
@@ -305,7 +305,7 @@ void __mpy_builtins_setup(void) {
     __mpy_obj_ref_inc(__mpy_super);
 }
 
-void __mpy_builtins_cleanup() {
+void __mpy_builtins_cleanup(void) {
     __mpy_obj_ref_dec(__MPyType_Object);
 
     __mpy_obj_ref_dec(__MPyType_Num);

--- a/c-runtime/src/literals/tuple.c
+++ b/c-runtime/src/literals/tuple.c
@@ -31,7 +31,7 @@ void __mpy_obj_cleanup_tuple(__MPyObj *self) {
 }
 
 __MPyObj* __mpy_obj_init_tuple(unsigned int size) {
-    __MPyObj *obj = __mpy_obj_new(__MPyType_Object);
+    __MPyObj *obj = __mpy_obj_new();
     obj->type = __MPyType_Tuple;
     obj->cleanupAction = __mpy_obj_cleanup_tuple;
 

--- a/c-runtime/src/mpy_obj.c
+++ b/c-runtime/src/mpy_obj.c
@@ -19,7 +19,7 @@ __MPyObj* __mpy_obj_return(__MPyObj *obj) {
     return obj; // return obj to allow chaining
 }
 
-__MPyObj* __mpy_obj_new() {
+__MPyObj* __mpy_obj_new(void) {
 #ifdef MINI_PYTHON_DEBUG
     fprintf(stderr, "DEBUG: __mpy_obj_new: creating new object with id '%d'\n", __MPyObjCount);
 #endif
@@ -107,7 +107,7 @@ __MPyObj* __mpy_obj_get_attr_rec(__MPyObj *self, const char *name, const char *t
     // and try calling the method after using the modifier method....)
     // we need to look up the class attributes and parent for attributes initialized in the parent,
     // static functions and non-overriden functions
-    
+
     // note: the recursion (or iteration, if recursion turns out to be suboptimal)
     // may need to cache the looked up classes, since in theory python3's MRO allows recursive inheritance
     // relationships

--- a/c-runtime/src/program.c
+++ b/c-runtime/src/program.c
@@ -3,10 +3,9 @@
 // It is stil here to allow compilation of the runtime.
 
 
-void smth() {
+void smth(void) {
 }
 
-int main() {
+int main(int argc, char *argv[]) {
     return 0;
 }
-

--- a/c-runtime/src/type-hierarchy/object.c
+++ b/c-runtime/src/type-hierarchy/object.c
@@ -74,7 +74,7 @@ __MPyObj *__mpy_object_get_attr_impl(__MPyObj *self, const char *name) {
     return __mpy_hash_map_get(self->content, (void*) name);
 }
 
-__MPyObj *__mpy_obj_init_object() {
+__MPyObj *__mpy_obj_init_object(void) {
     __MPyObj *obj = __mpy_obj_new();
     obj->type = __MPyType_Object;
     obj->content = __mpy_hash_map_init(&__mpy_hash_map_str_key_cmp);

--- a/src/main/java/CBuilder/ProgramBuilder.java
+++ b/src/main/java/CBuilder/ProgramBuilder.java
@@ -151,7 +151,7 @@ public class ProgramBuilder {
         }
         program.append('\n');
 
-        program.append("int main() {\n");
+        program.append("int main(int argc, char *argv[]) {\n");
 
         StringBuilder body = new StringBuilder();
 


### PR DESCRIPTION
fixes #14 